### PR TITLE
Correção nos erros na limitação de rede

### DIFF
--- a/connection/connection_handler.py
+++ b/connection/connection_handler.py
@@ -56,8 +56,8 @@ class ConnectionHandler(SimpleModule):
 
         self.timer = Timer.get_instance()
 
-    def get_traffic_shaping_positions(self):
-        current_tsi = self.timer.get_current_time() // self.traffic_shaping_interval
+    def get_traffic_shaping_positions(self, delta_time=0.0):
+        current_tsi = (self.timer.get_current_time() + delta_time) // self.traffic_shaping_interval
 
         if current_tsi > self.current_traffic_shaping_interval:
             self.current_traffic_shaping_interval = current_tsi
@@ -100,7 +100,7 @@ class ConnectionHandler(SimpleModule):
             st_data.append((target_throughput, self.traffic_shaping_interval))
 
             while length > 0:
-                tsp = self.__get_next_traffic_shaping_positions()
+                tsp = self.get_traffic_shaping_positions(waiting_time)
                 target_throughput = self.traffic_shaping_values[self.traffic_shaping_sequence[tsp[0]]][tsp[1]]
 
                 t = length / target_throughput

--- a/connection/connection_handler.py
+++ b/connection/connection_handler.py
@@ -67,11 +67,6 @@ class ConnectionHandler(SimpleModule):
 
         return self.tss_position, self.tsv_position
 
-    def __get_next_traffic_shaping_positions(self):
-        self.tss_position = (self.tss_position + 1) % len(self.traffic_shaping_sequence)
-        self.tsv_position = (self.tsv_position + 1) % len(self.traffic_shaping_values[0])
-        return self.tss_position, self.tsv_position
-
     def initialize(self):
         # self.send_down(Message(MessageKind.SEGMENT_REQUEST, 'Olá Mundo'))
         pass


### PR DESCRIPTION
Fecha a issue #11.

Comparação do caso em que o perfil "L" é pulado vs com a correção:

![throughput_errado](https://user-images.githubusercontent.com/13670489/138182295-63ccacb3-84cc-4c2c-bae9-ccad26cb0f7a.png)

![throughput_certo](https://user-images.githubusercontent.com/13670489/138182281-f8fc7db6-ffc1-41b9-a525-eba11737261b.png)

Comparação do caso com a string "HMHLH" atual(na esquerda) vs com a correção(na direita):

![HMHLH](https://user-images.githubusercontent.com/13670489/138182388-358ae549-aca9-4efc-8856-13eba84c7590.png)

Talvez seja possível melhorar o ponto de ínicio dos perfis, parece que começam um pouco depois do que deveriam.